### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.currentForm ).find( element ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/5](https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/5)

To fix the problem, we need to ensure that user input is always treated as a CSS selector and not as HTML. This can be achieved by using jQuery's `find` method instead of directly using the `$` function, which can interpret strings starting with `<` as HTML.

- Modify the `validationTargetFor` function to use `jQuery.find` instead of `$`.
- Ensure that all instances where user input is used in jQuery selectors are properly sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
