### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return this.currentForm ? $(this.currentForm).find(selector)[0] : $(selector)[0];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/4](https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/4)

To fix the issue, we need to ensure that the `selector` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly passing the `selector` to the jQuery function. This change will prevent the `selector` from being interpreted as HTML, thus mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
