### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe jQuery plugin

### DIFF
--- a/Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return this.currentForm ? $(this.currentForm).find(selector)[0] : $(selector)[0];
+			return this.currentForm ? $(this.currentForm).find(selector)[0] : $.find(selector)[0];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/6](https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/6)

To fix the problem, we need to ensure that the `selector` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method, which interprets the input as a CSS selector, rather than the `jQuery` function, which can interpret the input as HTML if it starts with `<`.

- Modify the `clean` function to use `jQuery.find` to ensure the `selector` is always treated as a CSS selector.
- Update the relevant lines in the `Project_SE/Project_SE/wwwroot/lib/jquery-validation/dist/jquery.validate.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
