### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe HTML constructed from library input

### DIFF
--- a/Project_SE/Project_SE/wwwroot/lib/jquery/dist/jquery.js
+++ b/Project_SE/Project_SE/wwwroot/lib/jquery/dist/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement('a');
+		anchor.id = expando;
+		anchor.href = '';
+		anchor.disabled = true;
+		el.appendChild(anchor);
+
+		var select = document.createElement('select');
+		select.id = expando + "-\r\\";
+		select.disabled = true;
+
+		var option = document.createElement('option');
+		option.selected = true;
+		select.appendChild(option);
+
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/3](https://github.com/Costinelos/SE_Project-RentABike/security/code-scanning/3)

To fix the problem, we need to ensure that the HTML construction does not use `innerHTML` with potentially unsafe data. Instead, we can use safer methods such as creating elements and setting their properties directly. This approach avoids the risk of XSS by not allowing any HTML content to be interpreted as code.

- Replace the use of `innerHTML` with methods that create elements and set their attributes directly.
- Specifically, in the file `Project_SE/Project_SE/wwwroot/lib/jquery/dist/jquery.js`, replace the lines that set `innerHTML` with code that creates the elements and appends them to the document.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
